### PR TITLE
Add path manipulation helpers

### DIFF
--- a/path.mbt
+++ b/path.mbt
@@ -204,11 +204,7 @@ pub fn Path::is_exists(self : Path) -> Bool {
 pub fn Path::file_name(self : Path) -> String? {
   let len = self.components.length()
   if len > 0 {
-    if self.is_file() {
-      Some(self.components[len - 1])
-    } else {
-      None
-    }
+    Some(self.components[len - 1])
   } else {
     None
   }
@@ -219,6 +215,8 @@ pub fn Path::parent(self : Path) -> Path? {
   let len = self.components.length()
   if len == 0 {
     None
+  } else if len == 1 && not(self.is_absolute) {
+    Some({ components: [], is_absolute: false })
   } else {
     let parent_components = Array::new()
     for i = 0; i < len - 1; i = i + 1 {
@@ -278,14 +276,19 @@ pub fn Path::to_absolute(self : Path) -> String {
 }
 
 ///|
-///
+/// 将路径转换为字符串
+/// 
+/// # 返回值
+/// 返回路径的字符串表示
+/// 
+/// # 示例
 /// ```mbt
 /// let p1 = Path::new("/home/user/file.txt")
 /// let p2 = Path::new("relative/path")
 /// inspect(p1.to_string(), content="/home/user/file.txt")
 /// inspect(p2.to_string(), content="relative/path")
 /// ```
-pub impl Show for Path with output(self, logger) {
+pub fn Path::to_string(self : Path) -> String {
   let sep = get_separator()
   let s = if self.is_absolute {
     if platform == "windows" {
@@ -340,5 +343,223 @@ pub impl Show for Path with output(self, logger) {
     }
     result
   }
-  logger.write_string(s)
+  s
+}
+
+///|
+pub impl Show for Path with output(self, logger) {
+  logger.write_string(self.to_string())
+}
+
+///|
+/// 获取文件扩展名
+/// 
+/// # 返回值
+/// 返回文件扩展名，如果没有扩展名则返回 None
+/// 
+/// # 示例
+/// ```mbt
+/// let p = Path::new("/home/user/file.txt")
+/// inspect(p.extension(), content="Some(\"txt\")")
+/// let p2 = Path::new("/home/user/file")
+/// inspect(p2.extension(), content="None")
+/// ```
+pub fn Path::extension(self : Path) -> String? {
+  match self.file_name() {
+    Some(name) => {
+      let mut last_dot = -1
+      for i = name.length() - 1; i >= 0; i = i - 1 {
+        if name.substring(start=i, end=i + 1) == "." {
+          last_dot = i
+          break
+        }
+      }
+      if last_dot > 0 && last_dot < name.length() - 1 {
+        Some(name.substring(start=last_dot + 1, end=name.length()))
+      } else {
+        None
+      }
+    }
+    None => None
+  }
+}
+
+///|
+/// 获取不带扩展名的文件名
+/// 
+/// # 返回值
+/// 返回不带扩展名的文件名，如果路径不是文件则返回 None
+/// 
+/// # 示例
+/// ```mbt
+/// let p = Path::new("/home/user/file.txt")
+/// inspect(p.file_stem(), content="Some(\"file\")")
+/// let p2 = Path::new("/home/user/archive.tar.gz")
+/// inspect(p2.file_stem(), content="Some(\"archive.tar\")")
+/// ```
+pub fn Path::file_stem(self : Path) -> String? {
+  match self.file_name() {
+    Some(name) => {
+      let mut last_dot = -1
+      for i = name.length() - 1; i >= 0; i = i - 1 {
+        if name.substring(start=i, end=i + 1) == "." {
+          last_dot = i
+          break
+        }
+      }
+      if last_dot > 0 {
+        Some(name.substring(start=0, end=last_dot))
+      } else {
+        Some(name)
+      }
+    }
+    None => None
+  }
+}
+
+///|
+/// 替换文件扩展名
+/// 
+/// # 参数
+/// - `extension`: 新的扩展名（不包含点号）
+/// 
+/// # 返回值
+/// 返回新的 Path 对象
+/// 
+/// # 示例
+/// ```mbt
+/// let p = Path::new("/home/user/file.txt")
+/// let p2 = p.with_extension("md")
+/// inspect(p2.to_string(), content="/home/user/file.md")
+/// ```
+pub fn Path::with_extension(self : Path, extension : String) -> Path {
+  let new_components = Array::new()
+  
+  if self.components.length() == 0 {
+    return { components: new_components, is_absolute: self.is_absolute }
+  }
+  
+  for i = 0; i < self.components.length() - 1; i = i + 1 {
+    new_components.push(self.components[i])
+  }
+  
+  let last_component = self.components[self.components.length() - 1]
+  let mut last_dot = -1
+  for i = last_component.length() - 1; i >= 0; i = i - 1 {
+    if last_component.substring(start=i, end=i + 1) == "." {
+      last_dot = i
+      break
+    }
+  }
+  
+  let stem = if last_dot > 0 {
+    last_component.substring(start=0, end=last_dot)
+  } else {
+    last_component
+  }
+  
+  let new_name = if extension == "" {
+    stem
+  } else {
+    stem + "." + extension
+  }
+  
+  new_components.push(new_name)
+  { components: new_components, is_absolute: self.is_absolute }
+}
+
+///|
+/// 连接多个路径组件
+/// 
+/// # 参数
+/// - `components`: 要连接的路径组件数组
+/// 
+/// # 返回值
+/// 返回新的 Path 对象
+/// 
+/// # 示例
+/// ```mbt
+/// let p = Path::new("/home/user")
+/// let p2 = p.join(["documents", "file.txt"])
+/// inspect(p2.to_string(), content="/home/user/documents/file.txt")
+/// ```
+pub fn Path::join(self : Path, components : Array[String]) -> Path {
+  let new_components = Array::new()
+  for component in self.components {
+    new_components.push(component)
+  }
+  
+  let result = { components: new_components, is_absolute: self.is_absolute }
+  for component in components {
+    result.push(component)
+  }
+  
+  result
+}
+
+///|
+/// 判断路径是否以指定路径开始
+/// 
+/// # 参数
+/// - `prefix`: 要检查的前缀路径
+/// 
+/// # 返回值
+/// 如果路径以指定路径开始则返回 true
+/// 
+/// # 示例
+/// ```mbt
+/// let p = Path::new("/home/user/documents")
+/// let prefix = Path::new("/home/user")
+/// inspect(p.starts_with(prefix), content="true")
+/// ```
+pub fn Path::starts_with(self : Path, prefix : Path) -> Bool {
+  if self.is_absolute != prefix.is_absolute {
+    return false
+  }
+  
+  if prefix.components.length() > self.components.length() {
+    return false
+  }
+  
+  for i = 0; i < prefix.components.length(); i = i + 1 {
+    if self.components[i] != prefix.components[i] {
+      return false
+    }
+  }
+  
+  true
+}
+
+///|
+/// 判断路径是否以指定路径结束
+/// 
+/// # 参数
+/// - `suffix`: 要检查的后缀路径
+/// 
+/// # 返回值
+/// 如果路径以指定路径结束则返回 true
+/// 
+/// # 示例
+/// ```mbt
+/// let p = Path::new("/home/user/documents/file.txt")
+/// let suffix = Path::new("documents/file.txt")
+/// inspect(p.ends_with(suffix), content="true")
+/// ```
+pub fn Path::ends_with(self : Path, suffix : Path) -> Bool {
+  if suffix.components.length() == 0 {
+    return self.components.length() == 0
+  }
+  
+  if suffix.components.length() > self.components.length() {
+    return false
+  }
+  
+  let offset = self.components.length() - suffix.components.length()
+  for i = 0; i < suffix.components.length(); i = i + 1 {
+    if self.components[offset + i] != suffix.components[i] {
+      return false
+    }
+  }
+  
+  true
 }

--- a/path_test.mbt
+++ b/path_test.mbt
@@ -171,3 +171,337 @@ test "当前目录处理特殊情况" {
       }
   }
 }
+
+///|
+test "Path::extension - 获取文件扩展名" {
+  // 测试普通文件扩展名
+  let p1 = Path::new("file.txt")
+  inspect(p1.extension(), content="Some(\"txt\")")
+  
+  let p2 = Path::new("/home/user/document.pdf")
+  inspect(p2.extension(), content="Some(\"pdf\")")
+  
+  // 测试多个点的情况
+  let p3 = Path::new("archive.tar.gz")
+  inspect(p3.extension(), content="Some(\"gz\")")
+  
+  // 测试没有扩展名的文件
+  let p4 = Path::new("/home/user/README")
+  inspect(p4.extension(), content="None")
+  
+  // 测试只有点的情况（隐藏文件）
+  let p5 = Path::new(".gitignore")
+  inspect(p5.extension(), content="None")
+  
+  // 测试以点结尾
+  let p6 = Path::new("file.")
+  inspect(p6.extension(), content="None")
+}
+
+///|
+test "Path::file_stem - 获取不带扩展名的文件名" {
+  // 测试普通文件
+  let p1 = Path::new("file.txt")
+  inspect(p1.file_stem(), content="Some(\"file\")")
+  
+  let p2 = Path::new("/home/user/document.pdf")
+  inspect(p2.file_stem(), content="Some(\"document\")")
+  
+  // 测试多个点的情况
+  let p3 = Path::new("archive.tar.gz")
+  inspect(p3.file_stem(), content="Some(\"archive.tar\")")
+  
+  // 测试没有扩展名
+  let p4 = Path::new("/home/user/README")
+  inspect(p4.file_stem(), content="Some(\"README\")")
+  
+  // 测试隐藏文件
+  let p5 = Path::new(".gitignore")
+  inspect(p5.file_stem(), content="Some(\".gitignore\")")
+}
+
+///|
+test "Path::with_extension - 替换文件扩展名" {
+  // 测试替换扩展名
+  let p1 = Path::new("/home/user/file.txt")
+  let p2 = p1.with_extension("md")
+  inspect(p2.to_string(), content="/home/user/file.md")
+  
+  // 测试移除扩展名
+  let p3 = Path::new("/home/user/file.txt")
+  let p4 = p3.with_extension("")
+  inspect(p4.to_string(), content="/home/user/file")
+  
+  // 测试没有扩展名的文件
+  let p5 = Path::new("/home/user/README")
+  let p6 = p5.with_extension("md")
+  inspect(p6.to_string(), content="/home/user/README.md")
+  
+  // 测试相对路径
+  let p7 = Path::new("src/main.mbt")
+  let p8 = p7.with_extension("rs")
+  inspect(p8.to_string(), content="src/main.rs")
+  
+  // 测试空路径
+  let p9 = Path::new("")
+  let p10 = p9.with_extension("txt")
+  inspect(p10.to_string(), content=".")
+}
+
+///|
+test "Path::join - 连接路径组件" {
+  // 测试基本连接
+  let p1 = Path::new("/home/user")
+  let p2 = p1.join(["documents", "file.txt"])
+  inspect(p2.to_string(), content="/home/user/documents/file.txt")
+  
+  // 测试空数组
+  let p3 = Path::new("/home/user")
+  let p4 = p3.join([])
+  inspect(p4.to_string(), content="/home/user")
+  
+  // 测试相对路径
+  let p5 = Path::new("src")
+  let p6 = p5.join(["lib", "utils.mbt"])
+  inspect(p6.to_string(), content="src/lib/utils.mbt")
+  
+  // 测试包含 .. 的组件
+  let p7 = Path::new("/home/user")
+  let p8 = p7.join(["documents", "..", "downloads"])
+  inspect(p8.to_string(), content="/home/user/downloads")
+  
+  // 测试单个组件
+  let p9 = Path::new("/home")
+  let p10 = p9.join(["user"])
+  inspect(p10.to_string(), content="/home/user")
+}
+
+///|
+test "Path::starts_with - 检查路径前缀" {
+  // 测试绝对路径前缀
+  let p1 = Path::new("/home/user/documents")
+  let prefix1 = Path::new("/home/user")
+  inspect(p1.starts_with(prefix1), content="true")
+  
+  let prefix2 = Path::new("/home")
+  inspect(p1.starts_with(prefix2), content="true")
+  
+  let prefix3 = Path::new("/home/user/documents")
+  inspect(p1.starts_with(prefix3), content="true")
+  
+  // 测试不匹配的前缀
+  let prefix4 = Path::new("/home/other")
+  inspect(p1.starts_with(prefix4), content="false")
+  
+  let prefix5 = Path::new("/home/user/documents/file")
+  inspect(p1.starts_with(prefix5), content="false")
+  
+  // 测试相对路径
+  let p2 = Path::new("src/lib/utils")
+  let prefix6 = Path::new("src")
+  inspect(p2.starts_with(prefix6), content="true")
+  
+  let prefix7 = Path::new("src/lib")
+  inspect(p2.starts_with(prefix7), content="true")
+  
+  // 测试绝对路径和相对路径混合
+  let prefix8 = Path::new("/src")
+  inspect(p2.starts_with(prefix8), content="false")
+}
+
+///|
+test "Path::ends_with - 检查路径后缀" {
+  // 测试绝对路径后缀
+  let p1 = Path::new("/home/user/documents/file.txt")
+  let suffix1 = Path::new("file.txt")
+  inspect(p1.ends_with(suffix1), content="true")
+  
+  let suffix2 = Path::new("documents/file.txt")
+  inspect(p1.ends_with(suffix2), content="true")
+  
+  let suffix3 = Path::new("user/documents/file.txt")
+  inspect(p1.ends_with(suffix3), content="true")
+  
+  // 测试不匹配的后缀
+  let suffix5 = Path::new("other.txt")
+  inspect(p1.ends_with(suffix5), content="false")
+  
+  // 绝对路径可以以相对路径的子部分结尾
+  let suffix6 = Path::new("documents/file.txt")
+  inspect(p1.ends_with(suffix6), content="true")
+  
+  // 测试完全相同的相对路径
+  let p1_rel = Path::new("home/user/documents/file.txt")
+  let suffix7 = Path::new("home/user/documents/file.txt")
+  inspect(p1_rel.ends_with(suffix7), content="true")
+  
+  // 测试相对路径
+  let p2 = Path::new("src/lib/utils.mbt")
+  let suffix8 = Path::new("utils.mbt")
+  inspect(p2.ends_with(suffix8), content="true")
+  
+  let suffix9 = Path::new("lib/utils.mbt")
+  inspect(p2.ends_with(suffix9), content="true")
+  
+  // 测试空路径
+  let empty1 = Path::new("")
+  let empty2 = Path::new("")
+  inspect(empty1.ends_with(empty2), content="true")
+}
+
+///|
+test "Path::file_name - 获取文件名" {
+  // 测试文件路径
+  let p1 = Path::new("path_test.mbt")
+  match p1.file_name() {
+    Some(name) => inspect(name, content="path_test.mbt")
+    None => fail("Should return file name")
+  }
+  
+  // 测试绝对路径
+  let p2 = Path::new("/home/user/document.txt")
+  match p2.file_name() {
+    Some(name) => inspect(name, content="document.txt")
+    None => fail("Should return file name")
+  }
+  
+  // 测试空路径
+  let p3 = Path::new("")
+  inspect(p3.file_name(), content="None")
+  
+  // 测试目录路径
+  let p4 = Path::new("/home/user/documents")
+  match p4.file_name() {
+    Some(name) => inspect(name, content="documents")
+    None => fail("Should return last component")
+  }
+}
+
+///|
+test "Path::parent - 获取父目录" {
+  // 测试绝对路径
+  let p1 = Path::new("/home/user/documents/file.txt")
+  match p1.parent() {
+    Some(parent) => inspect(parent.to_string(), content="/home/user/documents")
+    None => fail("Should have parent")
+  }
+  
+  // 测试多级父目录
+  let p2 = Path::new("/home/user")
+  match p2.parent() {
+    Some(parent) => inspect(parent.to_string(), content="/home")
+    None => fail("Should have parent")
+  }
+  
+  // 测试根目录
+  let p3 = Path::new("/")
+  inspect(p3.parent(), content="None")
+  
+  // 测试相对路径
+  let p4 = Path::new("src/lib/utils.mbt")
+  match p4.parent() {
+    Some(parent) => inspect(parent.to_string(), content="src/lib")
+    None => fail("Should have parent")
+  }
+  
+  // 测试单个组件的相对路径
+  let p5 = Path::new("file.txt")
+  match p5.parent() {
+    Some(parent) => inspect(parent.to_string(), content=".")
+    None => fail("Should have parent (empty relative path)")
+  }
+  
+  // 测试空路径
+  let p6 = Path::new("")
+  inspect(p6.parent(), content="None")
+}
+
+///|
+test "Path::is_dir - 检查是否为目录" {
+  // 测试当前目录
+  let p1 = Path::new(".")
+  inspect(p1.is_dir(), content="true")
+  
+  // 测试文件
+  let p2 = Path::new("path_test.mbt")
+  inspect(p2.is_dir(), content="false")
+  
+  // 测试不存在的路径
+  let p3 = Path::new("/nonexistent/path")
+  inspect(p3.is_dir(), content="false")
+}
+
+///|
+test "Path::is_file - 检查是否为文件" {
+  // 测试文件
+  let p1 = Path::new("path_test.mbt")
+  inspect(p1.is_file(), content="true")
+  
+  // 测试目录
+  let p2 = Path::new(".")
+  inspect(p2.is_file(), content="false")
+  
+  // 测试不存在的路径
+  let p3 = Path::new("/nonexistent/file.txt")
+  inspect(p3.is_file(), content="false")
+}
+
+///|
+test "Path::is_exists - 检查路径是否存在" {
+  // 测试存在的文件
+  let p1 = Path::new("path_test.mbt")
+  inspect(p1.is_exists(), content="true")
+  
+  // 测试存在的目录
+  let p2 = Path::new(".")
+  inspect(p2.is_exists(), content="true")
+  
+  // 测试不存在的路径
+  let p3 = Path::new("/nonexistent/path")
+  inspect(p3.is_exists(), content="false")
+}
+
+///|
+test "边界情况 - extension 和 file_stem" {
+  // 测试只有点的文件名
+  let p1 = Path::new(".")
+  inspect(p1.extension(), content="None")
+  inspect(p1.file_stem(), content="None")
+  
+  // 测试空路径
+  let p2 = Path::new("")
+  inspect(p2.extension(), content="None")
+  inspect(p2.file_stem(), content="None")
+}
+
+///|
+test "综合测试 - 复杂路径操作" {
+  // 创建路径并进行多种操作
+  let base = Path::new("/home/user")
+  
+  // 使用 join 添加路径
+  let doc_path = base.join(["documents", "project"])
+  inspect(doc_path.to_string(), content="/home/user/documents/project")
+  
+  // 检查前缀
+  let prefix = Path::new("/home/user")
+  inspect(doc_path.starts_with(prefix), content="true")
+  
+  // 检查后缀
+  let suffix = Path::new("documents/project")
+  inspect(doc_path.ends_with(suffix), content="true")
+  
+  // 添加文件
+  let file_path = doc_path.join(["main.mbt"])
+  inspect(file_path.to_string(), content="/home/user/documents/project/main.mbt")
+  
+  // 替换扩展名
+  let rust_file = file_path.with_extension("rs")
+  inspect(rust_file.to_string(), content="/home/user/documents/project/main.rs")
+  
+  // 获取父目录
+  match rust_file.parent() {
+    Some(parent) => inspect(parent.to_string(), content="/home/user/documents/project")
+    None => fail("Should have parent")
+  }
+}


### PR DESCRIPTION
This PR adds several utility methods for working with paths:

**New methods:**
- `to_string()` - convert path to string (was previously only in Show trait)
- `extension()` - get file extension
- `file_stem()` - get filename without extension
- `with_extension()` - change or remove extension
- `join()` - join path components
- `starts_with()` - check if path starts with prefix
- `ends_with()` - check if path ends with suffix

**Bug fixes:**
- `file_name()` now returns the last component for any path, not just files
- `parent()` now correctly handles single-component relative paths

**Tests:**
- Added tests for all new methods
- Added tests for `is_dir()`, `is_file()`, `is_exists()`
- Added tests for `file_name()` and `parent()`
- All 38 tests passing

These additions make the library more complete and easier to use for common path operations.
